### PR TITLE
Sockets security filtering

### DIFF
--- a/src/main/java/com/talentradar/talentradarnotificationservicerw/config/AuthFilter.java
+++ b/src/main/java/com/talentradar/talentradarnotificationservicerw/config/AuthFilter.java
@@ -31,18 +31,6 @@ public class AuthFilter extends OncePerRequestFilter {
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
 
-        String path = request.getRequestURI();
-        if (path.equals("/ws-notifications/info") ||
-                path.matches("/ws-notifications/\\d+/.*")) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        if (!path.startsWith("/ws-notifications")) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
         // Extract user information from headers
         String userId = request.getHeader(HEADER_USER_ID);
         String email = request.getHeader(HEADER_USER_EMAIL);

--- a/src/main/java/com/talentradar/talentradarnotificationservicerw/config/CookieAuthHandshakeInterceptor.java
+++ b/src/main/java/com/talentradar/talentradarnotificationservicerw/config/CookieAuthHandshakeInterceptor.java
@@ -2,13 +2,10 @@ package com.talentradar.talentradarnotificationservicerw.config;
 
 import com.talentradar.talentradarnotificationservicerw.domain.dtos.UserClaimsDTO;
 import com.talentradar.talentradarnotificationservicerw.utils.JwtUtil;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
-import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/src/main/java/com/talentradar/talentradarnotificationservicerw/config/SecurityConfig.java
+++ b/src/main/java/com/talentradar/talentradarnotificationservicerw/config/SecurityConfig.java
@@ -10,12 +10,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.List;
 
 @EnableWebSecurity
 @RequiredArgsConstructor


### PR DESCRIPTION
## 📄 Description
<!-- 
A clear and concise explanation of what this PR does. 
What feature, bugfix, or improvement does it deliver?
-->
- The PR fixes an issue where SockJS endpoints are forwarded to the cookie interceptor without headers attached
- The auth filter now authenticates and adds headers to the SockJS endpoints (`ws-notifications/**`)
## 🧪 How to Test
<!-- 
Steps for manually testing this PR (if applicable).
-->
- Run the notification service (presuming the other services needed are also running)
- Run the frontend client, and connect to the WebSocket 

## ✅ Checklist
<!-- 
Mark completed items with [x]
-->
- [x] Jira ticket linked in title or description
- [x] Follows branch naming convention: `type/service-JIRA-ID-description`
- [x] Follows commit naming convention: `type(JIRA-ID): Summary`
- [x] Code tested locally
- [x] Tests added or updated
- [ ] Documentation updated (if applicable)
- [x] No sensitive data or secrets committed

## 📝 Additional Notes
<!-- 
Add any extra context or implementation details.
-->
- Any known issues? N/A
- Follow-up tasks? N/A